### PR TITLE
fix: Remove dependency on browser environment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41,7 +41,7 @@ const getBrowser = async () => {
 };
 const scheduleBrowserForDestruction = () => {
     clearTimeout(browserDestructionTimeout);
-    browserDestructionTimeout = window.setTimeout(async () => {
+    browserDestructionTimeout = setTimeout(async () => {
         /* istanbul ignore next */
         if (browserInstance) {
             browserState = "closed";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-to-img",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coverage": "coveralls < ./coverage/lcov.info",
     "prebuild": "rm -rf dist/ && npm run lint",
     "build": "tsc --pretty",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-to-img",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "A node.js library to convert SVGs to images built with Puppeteer.",
   "homepage": "https://github.com/etienne-martin/svg-to-img",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const getBrowser = async (): Promise<puppeteer.Browser> => {
 
 const scheduleBrowserForDestruction = () => {
   clearTimeout(browserDestructionTimeout);
-  browserDestructionTimeout = window.setTimeout(async () => {
+  browserDestructionTimeout = setTimeout(async () => {
     /* istanbul ignore next */
     if (browserInstance) {
       browserState = "closed";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { config, defaultOptions, defaultPngShorthandOptions, defaultJpegShorthan
 import { IOptions, IShorthandOptions } from "./typings";
 
 const queue: Array<(result: puppeteer.Browser) => void> = [];
-let browserDestructionTimeout: number;
+let browserDestructionTimeout: NodeJS.Timeout;
 let browserInstance: puppeteer.Browser|undefined;
 let browserState: "closed"|"opening"|"open" = "closed";
 


### PR DESCRIPTION
Hi Etienne 👋🏻,

first of all thank you so much for this awesome library. When using it I've discovered a bug though.

It throws an error when executing in a node environment because of `window` not being defined.

```
(node:22740) UnhandledPromiseRejectionWarning: ReferenceError: window is not defined
    at scheduleBrowserForDestruction (.../node_modules/svg-to-img/dist/index.js:44:3)
```

You can find a related pull request fixing the issue.

Let me know what you think.

Roland