### PR TITLE
Add puppeteer configuration to allow usage of this library with pkg, bump Typescript version and installed shx for Windows builds

### DIFF
--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.defaultWebpShorthandOptions = exports.defaultJpegShorthandOptions = exports.defaultPngShorthandOptions = exports.defaultOptions = exports.config = void 0;
 exports.config = {
     supportedImageTypes: ["jpeg", "png", "webp"],
     jpegBackground: "#fff",

--- a/dist/helpers.d.ts
+++ b/dist/helpers.d.ts
@@ -1,14 +1,14 @@
 /// <reference types="node" />
-import { IBoundingBox } from "./typings";
+import { IBoundingBox, IOptions } from "./typings";
 export declare const getFileTypeFromPath: (path: string) => string;
 export declare const stringifyFunction: (func: any, ...argsArray: any[]) => string;
-export declare const writeFileAsync: (path: string, data: Buffer) => Promise<{}>;
+export declare const writeFileAsync: (path: string, data: Buffer) => Promise<void>;
 export declare const renderSvg: (svg: string, options: {
-    width?: number | undefined;
-    height?: number | undefined;
-    type: "jpeg" | "png" | "webp" | undefined;
-    quality: number | undefined;
-    background?: string | undefined;
-    clip?: IBoundingBox | undefined;
+    width?: IOptions["width"];
+    height?: IOptions["height"];
+    type: IOptions["type"];
+    quality: IOptions["quality"];
+    background?: IOptions["background"];
+    clip?: IBoundingBox;
     jpegBackground: string;
-}) => Promise<{}>;
+}) => Promise<unknown>;

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,10 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.renderSvg = exports.writeFileAsync = exports.stringifyFunction = exports.getFileTypeFromPath = void 0;
 const fs = require("fs");
-exports.getFileTypeFromPath = (path) => {
+const getFileTypeFromPath = (path) => {
     return path.toLowerCase().replace(new RegExp("jpg", "g"), "jpeg").split(".").reverse()[0];
 };
-exports.stringifyFunction = (func, ...argsArray) => {
+exports.getFileTypeFromPath = getFileTypeFromPath;
+const stringifyFunction = (func, ...argsArray) => {
     // Remove istanbul coverage instruments
     const functionString = func.toString().replace(/cov_(.+?)\+\+[,;]?/g, "");
     const args = [];
@@ -22,7 +24,8 @@ exports.stringifyFunction = (func, ...argsArray) => {
     }
     return `(${functionString})(${args.join(",")})`;
 };
-exports.writeFileAsync = async (path, data) => {
+exports.stringifyFunction = stringifyFunction;
+const writeFileAsync = async (path, data) => {
     return new Promise((resolve, reject) => {
         fs.writeFile(path, data, (err) => {
             if (err) {
@@ -32,7 +35,8 @@ exports.writeFileAsync = async (path, data) => {
         });
     });
 };
-exports.renderSvg = async (svg, options) => {
+exports.writeFileAsync = writeFileAsync;
+const renderSvg = async (svg, options) => {
     return new Promise((resolve, reject) => {
         const canvas = document.createElement("canvas");
         const ctx = canvas.getContext("2d");
@@ -96,3 +100,4 @@ exports.renderSvg = async (svg, options) => {
         img.src = "data:image/svg+xml;charset=utf8," + svg;
     });
 };
+exports.renderSvg = renderSvg;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 import { IOptions, IShorthandOptions } from "./typings";
-export declare const from: (svg: string | Buffer) => {
-    to: (options: IOptions) => Promise<string | Buffer>;
-    toPng: (options?: IShorthandOptions | undefined) => Promise<string | Buffer>;
-    toJpeg: (options?: IShorthandOptions | undefined) => Promise<string | Buffer>;
-    toWebp: (options?: IShorthandOptions | undefined) => Promise<string | Buffer>;
+export declare const from: (svg: Buffer | string) => {
+    to: (options: IOptions) => Promise<Buffer | string>;
+    toPng: (options?: IShorthandOptions | undefined) => Promise<Buffer | string>;
+    toJpeg: (options?: IShorthandOptions | undefined) => Promise<Buffer | string>;
+    toWebp: (options?: IShorthandOptions | undefined) => Promise<Buffer | string>;
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.from = void 0;
 const puppeteer = require("puppeteer");
 const helpers_1 = require("./helpers");
 const constants_1 = require("./constants");
@@ -21,7 +22,7 @@ const getBrowser = async (options) => {
             // Browser is closed
             queue.push(resolve);
             browserState = "opening";
-            browserInstance = await puppeteer.launch(Object.assign({}, constants_1.config.puppeteer, options));
+            browserInstance = await puppeteer.launch(Object.assign(Object.assign({}, constants_1.config.puppeteer), options));
             browserState = "open";
             return executeQueuedRequests(browserInstance);
         }
@@ -51,7 +52,7 @@ const scheduleBrowserForDestruction = () => {
 };
 const convertSvg = async (inputSvg, passedOptions) => {
     const svg = Buffer.isBuffer(inputSvg) ? inputSvg.toString("utf8") : inputSvg;
-    const options = Object.assign({}, constants_1.defaultOptions, passedOptions);
+    const options = Object.assign(Object.assign({}, constants_1.defaultOptions), passedOptions);
     const browser = await getBrowser(passedOptions.puppeteer);
     const page = (await browser.pages())[0];
     // ⚠️ Offline mode is enabled to prevent any HTTP requests over the network
@@ -92,20 +93,20 @@ const to = (svg) => {
 };
 const toPng = (svg) => {
     return async (options) => {
-        return convertSvg(svg, Object.assign({}, constants_1.defaultPngShorthandOptions, options));
+        return convertSvg(svg, Object.assign(Object.assign({}, constants_1.defaultPngShorthandOptions), options));
     };
 };
 const toJpeg = (svg) => {
     return async (options) => {
-        return convertSvg(svg, Object.assign({}, constants_1.defaultJpegShorthandOptions, options));
+        return convertSvg(svg, Object.assign(Object.assign({}, constants_1.defaultJpegShorthandOptions), options));
     };
 };
 const toWebp = (svg) => {
     return async (options) => {
-        return convertSvg(svg, Object.assign({}, constants_1.defaultWebpShorthandOptions, options));
+        return convertSvg(svg, Object.assign(Object.assign({}, constants_1.defaultWebpShorthandOptions), options));
     };
 };
-exports.from = (svg) => {
+const from = (svg) => {
     return {
         to: to(svg),
         toPng: toPng(svg),
@@ -113,3 +114,4 @@ exports.from = (svg) => {
         toWebp: toWebp(svg)
     };
 };
+exports.from = from;

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,14 +14,14 @@ const executeQueuedRequests = (browser) => {
     // Clear items from the queue
     queue.length = 0;
 };
-const getBrowser = async () => {
+const getBrowser = async (options) => {
     return new Promise(async (resolve) => {
         clearTimeout(browserDestructionTimeout);
         if (browserState === "closed") {
             // Browser is closed
             queue.push(resolve);
             browserState = "opening";
-            browserInstance = await puppeteer.launch(constants_1.config.puppeteer);
+            browserInstance = await puppeteer.launch(Object.assign({}, constants_1.config.puppeteer, options));
             browserState = "open";
             return executeQueuedRequests(browserInstance);
         }
@@ -52,7 +52,7 @@ const scheduleBrowserForDestruction = () => {
 const convertSvg = async (inputSvg, passedOptions) => {
     const svg = Buffer.isBuffer(inputSvg) ? inputSvg.toString("utf8") : inputSvg;
     const options = Object.assign({}, constants_1.defaultOptions, passedOptions);
-    const browser = await getBrowser();
+    const browser = await getBrowser(passedOptions.puppeteer);
     const page = (await browser.pages())[0];
     // ⚠️ Offline mode is enabled to prevent any HTTP requests over the network
     await page.setOfflineMode(true);

--- a/dist/typings/index.d.ts
+++ b/dist/typings/index.d.ts
@@ -1,3 +1,4 @@
+import { LaunchOptions } from "puppeteer";
 export interface IBoundingBox {
     x: number;
     y: number;
@@ -13,6 +14,7 @@ export interface IOptions {
     clip?: IBoundingBox;
     background?: string;
     encoding?: "base64" | "utf8" | "binary" | "hex";
+    puppeteer?: LaunchOptions;
 }
 export interface IShorthandOptions extends IOptions {
     type?: never;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2845,6 +2845,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -4944,6 +4950,15 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -5517,11 +5532,40 @@
         "jsonify": "~0.0.0"
       }
     },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "shx": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.3.tgz",
+      "integrity": "sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.4"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,10 +71,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-      "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==",
-      "dev": true
+      "version": "14.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
     },
     "@types/puppeteer": {
       "version": "1.10.1",
@@ -6186,12 +6185,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
-      "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest src --coverage --verbose",
     "test:watch": "jest src --coverage --verbose --watch",
     "coverage": "coveralls < ./coverage/lcov.info",
-    "prebuild": "rm -rf dist/ && npm run lint",
+    "prebuild": "shx rm -rf dist/ && npm run lint",
     "build": "tsc --pretty",
     "prepare": "npm run build"
   },
@@ -95,6 +95,7 @@
     "jest": "22.4.4",
     "jest-canvas-mock": "1.1.0",
     "rimraf": "2.6.2",
+    "shx": "^0.3.3",
     "ts-jest": "22.4.6",
     "tslint": "5.11.0",
     "tslint-config-prettier": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "tslint": "5.11.0",
     "tslint-config-prettier": "1.17.0",
     "tslint-eslint-rules": "4.1.1",
-    "typescript": "2.9.2"
+    "@types/node": "^14.14.22",
+    "typescript": "4.1.2"
   },
   "dependencies": {
     "puppeteer": "1.1.1"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,8 +27,8 @@ export const stringifyFunction = (func: any, ...argsArray: any[]) => {
 };
 
 export const writeFileAsync = async (path: string, data: Buffer) => {
-  return new Promise((resolve, reject) => {
-    fs.writeFile(path, data, (err: Error) => {
+  return new Promise<void>((resolve, reject) => {
+    fs.writeFile(path, data, (err: NodeJS.ErrnoException | null) => {
       if (err) { return reject(err); }
 
       resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const executeQueuedRequests = (browser: puppeteer.Browser) => {
   queue.length = 0;
 };
 
-const getBrowser = async (): Promise<puppeteer.Browser> => {
+const getBrowser = async (options?: puppeteer.LaunchOptions): Promise<puppeteer.Browser> => {
   return new Promise(async (resolve: (result: puppeteer.Browser) => void) => {
     clearTimeout(browserDestructionTimeout);
 
@@ -24,7 +24,10 @@ const getBrowser = async (): Promise<puppeteer.Browser> => {
       // Browser is closed
       queue.push(resolve);
       browserState = "opening";
-      browserInstance = await puppeteer.launch(config.puppeteer);
+      browserInstance = await puppeteer.launch({
+        ...config.puppeteer,
+        ...options
+      });
       browserState = "open";
 
       return executeQueuedRequests(browserInstance);
@@ -60,7 +63,7 @@ const scheduleBrowserForDestruction = () => {
 const convertSvg = async (inputSvg: Buffer|string, passedOptions: IOptions): Promise<Buffer|string> => {
   const svg = Buffer.isBuffer(inputSvg) ? (inputSvg as Buffer).toString("utf8") : inputSvg;
   const options = {...defaultOptions, ...passedOptions};
-  const browser = await getBrowser();
+  const browser = await getBrowser(passedOptions.puppeteer);
   const page = (await browser.pages())[0];
 
   // ⚠️ Offline mode is enabled to prevent any HTTP requests over the network

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -1,3 +1,5 @@
+import { LaunchOptions } from "puppeteer";
+
 export interface IBoundingBox {
   x: number;
   y: number;
@@ -14,6 +16,7 @@ export interface IOptions {
   clip?: IBoundingBox;
   background?: string;
   encoding?: "base64" | "utf8" | "binary" | "hex";
+  puppeteer?: LaunchOptions;
 }
 
 export interface IShorthandOptions extends IOptions {


### PR DESCRIPTION
I've just added the Puppeteer config object to the `svg-to-img` config object which I can pass from my app. pkg doesn't work with the default Puppeteer path so I needed to be able to specify chromium's folder.

As building didn't work on windows due to a `rm` call in the scripts, I installed shx and had to update typescript accordingly. Tested on both Windows 10 and Ubuntu 18.04

Tested on my own repo and it works fine, so even if this repo hasn't been updated in a while I'm putting in a PR.